### PR TITLE
add query for analysis and sample matched analysis given analysisId

### DIFF
--- a/src/main/java/bio/overture/songsearch/config/SearchFields.java
+++ b/src/main/java/bio/overture/songsearch/config/SearchFields.java
@@ -36,5 +36,7 @@ public class SearchFields {
   public static final String DONOR_ID = "donorId";
   public static final String SPECIMEN_ID = "specimenId";
   public static final String SAMPLE_ID = "sampleId";
+  public static final String SUBMITTER_SAMPLE_ID = "submitterSampleId";
+  public static final String MATCHED_NORMAL_SUBMITTER_SAMPLE_ID = "matchedNormalSubmitterSampleId";
   public static final String RUN_ID = "runId";
 }

--- a/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
+++ b/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
@@ -98,7 +98,6 @@ public class AnalysisDataFetcher {
     };
   }
 
-  @SneakyThrows
   private void validateAnalysisAndSamplesValidForQuery(Analysis analysis, List<FlatDonorSample> flatSamples) {
     if (analysis.getExperiment().get("experimental_strategy") == null) {
       throw new GraphQLException("Can't find matched T/N analyses for this analysis because it has no experimental_strategy!");

--- a/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
+++ b/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
@@ -18,29 +18,18 @@
 
 package bio.overture.songsearch.graphql;
 
-import static bio.overture.songsearch.config.SearchFields.*;
-import static bio.overture.songsearch.model.enums.SpecimenType.NORMAL;
-import static bio.overture.songsearch.model.enums.SpecimenType.TUMOUR;
-import static java.util.stream.Collectors.toUnmodifiableList;
-
 import bio.overture.songsearch.model.Analysis;
-import bio.overture.songsearch.model.Sample;
 import bio.overture.songsearch.model.SampleMatchedAnalysisPair;
 import bio.overture.songsearch.service.AnalysisService;
 import com.google.common.collect.ImmutableMap;
-import graphql.AssertException;
-import graphql.GraphQLException;
 import graphql.schema.DataFetcher;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import lombok.SneakyThrows;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component

--- a/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
+++ b/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
@@ -130,6 +130,10 @@ public class GraphQLProvider {
         .type(
             newTypeWiring("Query")
                 .dataFetcher("files", fileDataFetcher.getFilesDataFetcher()))
+        .type(
+            newTypeWiring("Query")
+                .dataFetcher(
+                    "analysisAndSampleMatchedAnalysis", analysisDataFetcher.getAnalysisAndSampleMatchedAnalysesFetcher()))
         .build();
   }
 

--- a/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
+++ b/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
@@ -133,7 +133,7 @@ public class GraphQLProvider {
         .type(
             newTypeWiring("Query")
                 .dataFetcher(
-                    "analysisAndSampleMatchedAnalysis", analysisDataFetcher.getAnalysisAndSampleMatchedAnalysesFetcher()))
+                    "sampleMatchedAnalysisPairs", analysisDataFetcher.getSampleMatchedAnalysisPairsFetcher()))
         .build();
   }
 

--- a/src/main/java/bio/overture/songsearch/model/MatchedAnalysisPair.java
+++ b/src/main/java/bio/overture/songsearch/model/MatchedAnalysisPair.java
@@ -1,0 +1,9 @@
+package bio.overture.songsearch.model;
+
+import lombok.Value;
+
+@Value
+public class MatchedAnalysisPair {
+  Analysis analysis;
+  Analysis matchedAnalysis;
+}

--- a/src/main/java/bio/overture/songsearch/model/MatchedAnalysisPair.java
+++ b/src/main/java/bio/overture/songsearch/model/MatchedAnalysisPair.java
@@ -1,9 +1,0 @@
-package bio.overture.songsearch.model;
-
-import lombok.Value;
-
-@Value
-public class MatchedAnalysisPair {
-  Analysis analysis;
-  Analysis matchedAnalysis;
-}

--- a/src/main/java/bio/overture/songsearch/model/SampleMatchedAnalysisPair.java
+++ b/src/main/java/bio/overture/songsearch/model/SampleMatchedAnalysisPair.java
@@ -1,0 +1,9 @@
+package bio.overture.songsearch.model;
+
+import lombok.Value;
+
+@Value
+public class SampleMatchedAnalysisPair {
+  Analysis normalSampleAnalysis;
+  Analysis tumourSampleAnalysis;
+}

--- a/src/main/java/bio/overture/songsearch/model/enums/SpecimenType.java
+++ b/src/main/java/bio/overture/songsearch/model/enums/SpecimenType.java
@@ -1,0 +1,17 @@
+package bio.overture.songsearch.model.enums;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum SpecimenType {
+  NORMAL("Normal"),
+  TUMOUR("Tumour");
+
+  @NonNull private final String value;
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
+++ b/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
@@ -86,6 +86,16 @@ public class AnalysisRepository {
             value ->
                 new NestedQueryBuilder(
                     "donors.specimens.samples", new TermQueryBuilder("donors.specimens.samples.sample_id", value), ScoreMode.None))
+       .put(
+               MATCHED_NORMAL_SUBMITTER_SAMPLE_ID,
+           value ->
+                new NestedQueryBuilder(
+                   "donors.specimens.samples", new TermQueryBuilder("donors.specimens.samples.matched_normal_submitter_sample_id", value), ScoreMode.None))
+       .put(
+           SUBMITTER_SAMPLE_ID,
+           value ->
+               new NestedQueryBuilder(
+                   "donors.specimens.samples", new TermQueryBuilder("donors.specimens.samples.submitter_sample_id", value), ScoreMode.None))
         .build();
   }
 

--- a/src/main/java/bio/overture/songsearch/utils/ElasticsearchQueryUtils.java
+++ b/src/main/java/bio/overture/songsearch/utils/ElasticsearchQueryUtils.java
@@ -22,6 +22,7 @@ import lombok.val;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
 
 import java.util.Map;
 import java.util.function.Function;
@@ -38,7 +39,16 @@ public class ElasticsearchQueryUtils {
       Map<String, Function<String, AbstractQueryBuilder<?>>> QUERY_RESOLVER,
       Map<String, Object> args) {
     val bool = QueryBuilders.boolQuery();
-    args.forEach((key, value) -> bool.must(QUERY_RESOLVER.get(key).apply(value.toString())));
+    args.forEach((key, value) ->
+                         bool.must(
+                                 QUERY_RESOLVER
+                                         .getOrDefault(key, simpleTermQueryBuilder(key))
+                                         .apply(value.toString())
+                         ));
     return bool;
+  }
+
+  private static Function<String, AbstractQueryBuilder<?>> simpleTermQueryBuilder(String key) {
+    return v -> new TermQueryBuilder(key, v);
   }
 }

--- a/src/main/java/bio/overture/songsearch/utils/ElasticsearchQueryUtils.java
+++ b/src/main/java/bio/overture/songsearch/utils/ElasticsearchQueryUtils.java
@@ -42,13 +42,13 @@ public class ElasticsearchQueryUtils {
     args.forEach((key, value) ->
                          bool.must(
                                  QUERY_RESOLVER
-                                         .getOrDefault(key, simpleTermQueryBuilder(key))
+                                         .getOrDefault(key, simpleTermQueryBuilderResolver(key))
                                          .apply(value.toString())
                          ));
     return bool;
   }
 
-  private static Function<String, AbstractQueryBuilder<?>> simpleTermQueryBuilder(String key) {
+  private static Function<String, AbstractQueryBuilder<?>> simpleTermQueryBuilderResolver(String key) {
     return v -> new TermQueryBuilder(key, v);
   }
 }

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -142,7 +142,13 @@ type Run @key(fields: "runId") @extends {
     inputAnalyses: [Analysis] @requires(fields: "parameters")
 }
 
+type MatchedAnalysisPair {
+    analysis: Analysis
+    matchedAnalysis: Analysis
+}
+
 extend type Query {
     analyses(filter: AnalysisFilter, page: Page): [Analysis]
     files(filter: FileFilter, page: Page): [File]
+    analysisAndSampleMatchedAnalysis(analysisId: String!): MatchedAnalysisPair
 }

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -142,13 +142,13 @@ type Run @key(fields: "runId") @extends {
     inputAnalyses: [Analysis] @requires(fields: "parameters")
 }
 
-type MatchedAnalysisPair {
-    analysis: Analysis
-    matchedAnalysis: Analysis
+type SampleMatchedAnalysisPair {
+    normalSampleAnalysis: Analysis
+    tumourSampleAnalysis: Analysis
 }
 
 extend type Query {
     analyses(filter: AnalysisFilter, page: Page): [Analysis]
     files(filter: FileFilter, page: Page): [File]
-    analysisAndSampleMatchedAnalysis(analysisId: String!): MatchedAnalysisPair
+    sampleMatchedAnalysisPairs(analysisId: String!): [SampleMatchedAnalysisPair]
 }


### PR DESCRIPTION
Add new query `sampleMatchedAnalysisPairs` which:
 - returns analysis for a given analysisId with all other analysis of same analysisType, expirmental_strategy and the matched normal/tumour sample
 - returns data as array of normal and tumour matched analyses pairs