### PR TITLE
adds inputAnalyses and producedAnalyses filters

### DIFF
--- a/src/main/java/bio/overture/songsearch/graphql/EntityDataFetcher.java
+++ b/src/main/java/bio/overture/songsearch/graphql/EntityDataFetcher.java
@@ -101,7 +101,7 @@ public class EntityDataFetcher {
       ImmutableMap<String, Object> filter = asImmutableMap(environment.getArgument("filter"));
       val filerAnalysisId = filter.get(ANALYSIS_ID);
 
-      val multipleFilters =
+      val multipleMergedFilters =
           inputAnalysisIds.stream()
               .map(
                   id -> {
@@ -113,11 +113,11 @@ public class EntityDataFetcher {
               .collect(toList());
 
       // short circuit here, otherwise will get all analysis
-      if (multipleFilters.size() < 1) {
+      if (multipleMergedFilters.size() < 1) {
         return List.of();
       }
 
-      return analysisService.getAnalyses(multipleFilters);
+      return analysisService.getAnalyses(multipleMergedFilters);
     };
   }
 
@@ -126,15 +126,15 @@ public class EntityDataFetcher {
       ImmutableMap<String, Object> filter = asImmutableMap(environment.getArgument("filter"));
       val filterRunId = filter.getOrDefault(RUN_ID, runId);
 
-      // short circuit here if can't find produced analysis for valid runId
+      // short circuit here since can't find produced analysis for invalid runId
       if (isNullOrEmpty(runId) || !runId.equals(filterRunId)) {
         return List.of();
       }
 
-      Map<String, Object> map = new HashMap<>(filter);
-      map.put(RUN_ID, runId);
+      Map<String, Object> mergedFilter = new HashMap<>(filter);
+      mergedFilter.put(RUN_ID, runId);
 
-      return analysisService.getAnalyses(map, null);
+      return analysisService.getAnalyses(mergedFilter, null);
     };
   }
 

--- a/src/main/java/bio/overture/songsearch/model/Run.java
+++ b/src/main/java/bio/overture/songsearch/model/Run.java
@@ -18,16 +18,17 @@
 
 package bio.overture.songsearch.model;
 
+import bio.overture.songsearch.service.AnalysisService;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
 import java.util.Map;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NonNull;
-import lombok.SneakyThrows;
+
+import com.google.common.collect.ImmutableMap;
+import graphql.schema.DataFetchingEnvironment;
+import lombok.*;
 
 @Data
 @AllArgsConstructor
@@ -42,8 +43,19 @@ public class Run {
 
   private List<Analysis> inputAnalyses;
 
+//  private AnalysisService analysisService;
+//
+//  public Run(String runId, AnalysisService analysisService) {
+//    this.runId = runId;
+//    this.analysisService = analysisService;
+//  }
+
   @SneakyThrows
   public static Run parse(@NonNull Map<String, Object> sourceMap) {
     return MAPPER.convertValue(sourceMap, Run.class);
   }
+
+  public List<Analysis> getInputAnalyses(DataFetchingEnvironment environment) {
+      return List.of();
+  };
 }

--- a/src/main/java/bio/overture/songsearch/model/Run.java
+++ b/src/main/java/bio/overture/songsearch/model/Run.java
@@ -18,17 +18,18 @@
 
 package bio.overture.songsearch.model;
 
-import bio.overture.songsearch.service.AnalysisService;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-import graphql.schema.DataFetchingEnvironment;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.SneakyThrows;
 
 @Data
 @AllArgsConstructor
@@ -39,23 +40,22 @@ public class Run {
 
   private String runId;
 
-  private List<Analysis> producedAnalyses;
+  private DataFetcher<List<Analysis>> producedAnalysesFetcher;
 
-  private List<Analysis> inputAnalyses;
-
-//  private AnalysisService analysisService;
-//
-//  public Run(String runId, AnalysisService analysisService) {
-//    this.runId = runId;
-//    this.analysisService = analysisService;
-//  }
+  private DataFetcher<List<Analysis>> inputAnalysesFetcher;
 
   @SneakyThrows
   public static Run parse(@NonNull Map<String, Object> sourceMap) {
     return MAPPER.convertValue(sourceMap, Run.class);
   }
 
-  public List<Analysis> getInputAnalyses(DataFetchingEnvironment environment) {
-      return List.of();
-  };
+  @SneakyThrows
+  public List<Analysis> getInputAnalyses(DataFetchingEnvironment env) {
+    return inputAnalysesFetcher.get(env);
+  }
+
+  @SneakyThrows
+  public List<Analysis> getProducedAnalyses(DataFetchingEnvironment env) {
+    return producedAnalysesFetcher.get(env);
+  }
 }

--- a/src/main/java/bio/overture/songsearch/service/AnalysisService.java
+++ b/src/main/java/bio/overture/songsearch/service/AnalysisService.java
@@ -22,7 +22,6 @@ import static bio.overture.songsearch.config.SearchFields.*;
 import static bio.overture.songsearch.model.enums.SpecimenType.NORMAL;
 import static bio.overture.songsearch.model.enums.SpecimenType.TUMOUR;
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 import bio.overture.songsearch.model.Analysis;
@@ -72,9 +71,7 @@ public class AnalysisService {
     return hitStream.map(AnalysisService::hitToAnalysis).collect(toUnmodifiableList());
   }
 
-  public List<Analysis> getAnalysesById(List<String> analysisIds) {
-    val multipleFilters =
-        analysisIds.stream().map(id -> Map.of(ANALYSIS_ID, (Object) id)).collect(toList());
+  public List<Analysis> getAnalyses(List<Map<String, Object>> multipleFilters) {
     val multiSearchResponse = analysisRepository.getAnalyses(multipleFilters, null);
     return Arrays.stream(multiSearchResponse.getResponses())
         .map(MultiSearchResponse.Item::getResponse)

--- a/src/main/java/bio/overture/songsearch/utils/CommonUtils.java
+++ b/src/main/java/bio/overture/songsearch/utils/CommonUtils.java
@@ -11,14 +11,14 @@ public final class CommonUtils {
   private CommonUtils() {}
 
   public static <K, V> ImmutableMap<K, V> asImmutableMap(Object obj) {
-    val newFilter = ImmutableMap.<K, V>builder();
+    val newMap = ImmutableMap.<K, V>builder();
     if (obj instanceof Map) {
       try {
-        newFilter.putAll((Map<? extends K, ? extends V>) obj);
+        newMap.putAll((Map<? extends K, ? extends V>) obj);
       } catch (ClassCastException e) {
         log.error("Failed to cast obj to Map<K,V>");
       }
     }
-    return newFilter.build();
+    return newMap.build();
   }
 }

--- a/src/main/java/bio/overture/songsearch/utils/CommonUtils.java
+++ b/src/main/java/bio/overture/songsearch/utils/CommonUtils.java
@@ -1,0 +1,24 @@
+package bio.overture.songsearch.utils;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+public final class CommonUtils {
+
+  private CommonUtils() {}
+
+  public static <K, V> ImmutableMap<K, V> asImmutableMap(Object obj) {
+    val newFilter = ImmutableMap.<K, V>builder();
+    if (obj instanceof Map) {
+      try {
+        newFilter.putAll((Map<? extends K, ? extends V>) obj);
+      } catch (ClassCastException e) {
+        log.error("Failed to cast obj to Map<K,V>");
+      }
+    }
+    return newFilter.build();
+  }
+}

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -138,8 +138,8 @@ input Page {
 type Run @key(fields: "runId") @extends {
     runId: ID! @external
     parameters: JSON @external
-    producedAnalyses: [Analysis]
-    inputAnalyses: [Analysis] @requires(fields: "parameters")
+    producedAnalyses(filter: AnalysisFilter, page: Page): [Analysis]
+    inputAnalyses(filter: AnalysisFilter, page: Page): [Analysis] @requires(fields: "parameters")
 }
 
 type SampleMatchedAnalysisPair {

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -135,11 +135,13 @@ input Page {
     from: Int!
 }
 
+directive @fetch(from : String!) on FIELD_DEFINITION
+
 type Run @key(fields: "runId") @extends {
     runId: ID! @external
     parameters: JSON @external
-    producedAnalyses(filter: AnalysisFilter, page: Page): [Analysis]
-    inputAnalyses(filter: AnalysisFilter, page: Page): [Analysis] @requires(fields: "parameters")
+    producedAnalyses(filter: AnalysisFilter): [Analysis] @fetch(from: "producedAnalyses")
+    inputAnalyses(filter: AnalysisFilter): [Analysis] @requires(fields: "parameters") @fetch(from: "inputAnalyses")
 }
 
 type SampleMatchedAnalysisPair {


### PR DESCRIPTION
Proposed changes:
- Extends schema so `inputAnalyses:[Analysis]` will now be `inputAnalyses(filter: AnalysisFilter):[Analysis]` and `producedAnalyses:[Analysis]` will now be `producedAnalyses(filter: AnalysisFilter):[Analysis]` 
- Modify Run to take DataFetchers instead of the data so they can use the input variables from query to filter