### PR TITLE
adds sorts and extend analysis query which has paging info

### DIFF
--- a/src/main/java/bio/overture/songsearch/config/SearchFields.java
+++ b/src/main/java/bio/overture/songsearch/config/SearchFields.java
@@ -45,7 +45,7 @@ public class SearchFields {
   public static final String MATCHED_NORMAL_SUBMITTER_SAMPLE_ID = "matchedNormalSubmitterSampleId";
   public static final String RUN_ID = "runId";
 
-  public static final Map<String, String> ANALYSIS_GQL_FIELD_TO_ES_FIELD =
+  public static final Map<String, String> ANALYSIS_QUERY_TO_ES_DOC_PATHS =
       ImmutableMap.copyOf(
           ofEntries(
               entry(ANALYSIS_ID, "analysis_id"),
@@ -53,31 +53,32 @@ public class SearchFields {
               entry(ANALYSIS_VERSION, "analysis_version"),
               entry(ANALYSIS_STATE, "analysis_state"),
               entry(STUDY_ID, "study_id"),
-              entry(RUN_ID, "run_id")));
+              entry(RUN_ID, "workflow.run_id")));
 
-  public static final Map<String, NestedField> ANALYSIS_GQL_FIELD_TO_ES_NESTED_FIELD =
+  public static final Map<String, NestedFieldPath> ANALYSIS_QUERY_TO_ES_NESTED_DOC_PATHS =
       ImmutableMap.copyOf(
           ofEntries(
-              entry(DONOR_ID, new NestedField("donors", "donors.donor_id")),
+              entry(DONOR_ID, new NestedFieldPath("donors", "donors.donor_id")),
               entry(
-                  SPECIMEN_ID, new NestedField("donors.specimens", "donors.specimens.specimen_id")),
+                  SPECIMEN_ID,
+                  new NestedFieldPath("donors.specimens", "donors.specimens.specimen_id")),
               entry(
                   SAMPLE_ID,
-                  new NestedField(
+                  new NestedFieldPath(
                       "donors.specimens.samples", "donors.specimens.samples.sample_id")),
               entry(
                   MATCHED_NORMAL_SUBMITTER_SAMPLE_ID,
-                  new NestedField(
+                  new NestedFieldPath(
                       "donors.specimens.samples",
                       "donors.specimens.samples.matched_normal_submitter_sample_id")),
               entry(
                   SUBMITTER_SAMPLE_ID,
-                  new NestedField(
+                  new NestedFieldPath(
                       "donors.specimens.samples",
                       "donors.specimens.samples.submitter_sample_id"))));
 
   @Value
-  public static class NestedField {
+  public static class NestedFieldPath {
     String objectPath;
     String fieldPath;
   }

--- a/src/main/java/bio/overture/songsearch/config/SearchFields.java
+++ b/src/main/java/bio/overture/songsearch/config/SearchFields.java
@@ -18,9 +18,14 @@
 
 package bio.overture.songsearch.config;
 
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
 import static lombok.AccessLevel.PRIVATE;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import lombok.NoArgsConstructor;
+import lombok.Value;
 
 @NoArgsConstructor(access = PRIVATE)
 public class SearchFields {
@@ -39,4 +44,41 @@ public class SearchFields {
   public static final String SUBMITTER_SAMPLE_ID = "submitterSampleId";
   public static final String MATCHED_NORMAL_SUBMITTER_SAMPLE_ID = "matchedNormalSubmitterSampleId";
   public static final String RUN_ID = "runId";
+
+  public static final Map<String, String> ANALYSIS_GQL_FIELD_TO_ES_FIELD =
+      ImmutableMap.copyOf(
+          ofEntries(
+              entry(ANALYSIS_ID, "analysis_id"),
+              entry(ANALYSIS_TYPE, "analysis_type"),
+              entry(ANALYSIS_VERSION, "analysis_version"),
+              entry(ANALYSIS_STATE, "analysis_state"),
+              entry(STUDY_ID, "study_id"),
+              entry(RUN_ID, "run_id")));
+
+  public static final Map<String, NestedField> ANALYSIS_GQL_FIELD_TO_ES_NESTED_FIELD =
+      ImmutableMap.copyOf(
+          ofEntries(
+              entry(DONOR_ID, new NestedField("donors", "donors.donor_id")),
+              entry(
+                  SPECIMEN_ID, new NestedField("donors.specimens", "donors.specimens.specimen_id")),
+              entry(
+                  SAMPLE_ID,
+                  new NestedField(
+                      "donors.specimens.samples", "donors.specimens.samples.sample_id")),
+              entry(
+                  MATCHED_NORMAL_SUBMITTER_SAMPLE_ID,
+                  new NestedField(
+                      "donors.specimens.samples",
+                      "donors.specimens.samples.matched_normal_submitter_sample_id")),
+              entry(
+                  SUBMITTER_SAMPLE_ID,
+                  new NestedField(
+                      "donors.specimens.samples",
+                      "donors.specimens.samples.submitter_sample_id"))));
+
+  @Value
+  public static class NestedField {
+    String objectPath;
+    String fieldPath;
+  }
 }

--- a/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
+++ b/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
@@ -18,9 +18,15 @@
 
 package bio.overture.songsearch.graphql;
 
+import static bio.overture.songsearch.utils.JacksonUtils.convertValue;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import bio.overture.songsearch.model.Analysis;
+import bio.overture.songsearch.model.ProbeResult;
 import bio.overture.songsearch.model.SampleMatchedAnalysisPair;
+import bio.overture.songsearch.model.Sort;
 import bio.overture.songsearch.service.AnalysisService;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import graphql.schema.DataFetcher;
 import java.util.List;
@@ -54,6 +60,29 @@ public class AnalysisDataFetcher {
         if (args.get("page") != null) page.putAll((Map<String, Integer>) args.get("page"));
       }
       return analysisService.getAnalyses(filter.build(), page.build());
+    };
+  }
+
+  public DataFetcher<ProbeResult<Analysis>> getProbeAnalysesDataFetcher() {
+    return environment -> {
+      val args = environment.getArguments();
+
+      val filter = ImmutableMap.<String, Object>builder();
+      val page = ImmutableMap.<String, Integer>builder();
+      val sorts = ImmutableList.<Sort>builder();
+
+      if (args != null) {
+        if (args.get("filter") != null) filter.putAll((Map<String, Object>) args.get("filter"));
+        if (args.get("page") != null) page.putAll((Map<String, Integer>) args.get("page"));
+        if (args.get("sorts") != null) {
+          val rawSorts = (List<Object>) args.get("sorts");
+          sorts.addAll(
+              rawSorts.stream()
+                  .map(sort -> convertValue(sort, Sort.class))
+                  .collect(toUnmodifiableList()));
+        }
+      }
+      return analysisService.probeAnalyses(filter.build(), page.build(), sorts.build());
     };
   }
 

--- a/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
+++ b/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
@@ -127,6 +127,9 @@ public class GraphQLProvider {
         .type(
             newTypeWiring("Query")
                 .dataFetcher("analyses", analysisDataFetcher.getAnalysesDataFetcher()))
+        .type(
+            newTypeWiring("Query")
+                .dataFetcher("probeAnalyses", analysisDataFetcher.getProbeAnalysesDataFetcher()))
         .type(newTypeWiring("Query").dataFetcher("files", fileDataFetcher.getFilesDataFetcher()))
         .type(
             newTypeWiring("Query")

--- a/src/main/java/bio/overture/songsearch/model/ProbeResult.java
+++ b/src/main/java/bio/overture/songsearch/model/ProbeResult.java
@@ -1,0 +1,22 @@
+package bio.overture.songsearch.model;
+
+import java.util.List;
+import lombok.Value;
+
+@Value
+public class ProbeResult<T> {
+  List<T> content;
+  Info info;
+
+  public ProbeResult(List<T> content, Boolean hasNextFrom, Long totalHits) {
+    this.content = content;
+    this.info = new Info(hasNextFrom, totalHits, content.size());
+  }
+
+  @Value
+  public static class Info {
+    Boolean hasNextFrom;
+    Long totalHits;
+    Integer contentCount;
+  }
+}

--- a/src/main/java/bio/overture/songsearch/model/Sort.java
+++ b/src/main/java/bio/overture/songsearch/model/Sort.java
@@ -1,0 +1,9 @@
+package bio.overture.songsearch.model;
+
+import lombok.Data;
+
+@Data
+public class Sort {
+  String fieldName;
+  String order;
+}

--- a/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
+++ b/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
@@ -74,19 +74,19 @@ public class AnalysisRepository {
   private static Map<String, Function<String, AbstractQueryBuilder<?>>> argumentPathMap() {
     val immutableMap = ImmutableMap.<String, Function<String, AbstractQueryBuilder<?>>>builder();
 
-    ANALYSIS_GQL_FIELD_TO_ES_FIELD.forEach(
-        (k, v) -> {
-          immutableMap.put(k, value -> new TermQueryBuilder(v, value));
+    ANALYSIS_QUERY_TO_ES_DOC_PATHS.forEach(
+        (k, fieldPath) -> {
+          immutableMap.put(k, value -> new TermQueryBuilder(fieldPath, value));
         });
 
-    ANALYSIS_GQL_FIELD_TO_ES_NESTED_FIELD.forEach(
-        (k, v) -> {
+    ANALYSIS_QUERY_TO_ES_NESTED_DOC_PATHS.forEach(
+        (k, nestedFieldPath) -> {
           immutableMap.put(
               k,
               value ->
                   new NestedQueryBuilder(
-                      v.getObjectPath(),
-                      new TermQueryBuilder(v.getFieldPath(), value),
+                      nestedFieldPath.getObjectPath(),
+                      new TermQueryBuilder(nestedFieldPath.getFieldPath(), value),
                       ScoreMode.None));
         });
 
@@ -96,10 +96,10 @@ public class AnalysisRepository {
   private static Map<String, FieldSortBuilder> sortBuilderMap() {
     val immutableMap = ImmutableMap.<String, FieldSortBuilder>builder();
 
-    ANALYSIS_GQL_FIELD_TO_ES_FIELD.forEach(
+    ANALYSIS_QUERY_TO_ES_DOC_PATHS.forEach(
         (k, v) -> immutableMap.put(k, SortBuilders.fieldSort(v)));
 
-    ANALYSIS_GQL_FIELD_TO_ES_NESTED_FIELD.forEach(
+    ANALYSIS_QUERY_TO_ES_NESTED_DOC_PATHS.forEach(
         (k, v) -> {
           val sortBuilder =
               SortBuilders.fieldSort(v.getFieldPath())
@@ -151,7 +151,7 @@ public class AnalysisRepository {
     val searchSourceBuilder = new SearchSourceBuilder();
 
     if (sorts.isEmpty()) {
-      searchSourceBuilder.sort(ANALYSIS_GQL_FIELD_TO_ES_FIELD.get(ANALYSIS_ID), SortOrder.ASC);
+      searchSourceBuilder.sort(ANALYSIS_QUERY_TO_ES_DOC_PATHS.get(ANALYSIS_ID), SortOrder.ASC);
     } else {
       val sortBuilders = sortsToEsSortBuilders(SORT_BUILDER_RESOLVERS, sorts);
       sortBuilders.forEach(searchSourceBuilder::sort);

--- a/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
+++ b/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
@@ -115,13 +115,13 @@ public class AnalysisRepository {
   }
 
   public SearchResponse getAnalyses(
-      Map<String, Object> filter, Map<String, Integer> page, List<Sort> sort) {
+      Map<String, Object> filter, Map<String, Integer> page, List<Sort> sorts) {
     final AbstractQueryBuilder<?> query =
         (filter == null || filter.size() == 0)
             ? matchAllQuery()
             : queryFromArgs(QUERY_RESOLVER, filter);
 
-    val searchSourceBuilder = createSearchSourceBuilder(query, page, sort);
+    val searchSourceBuilder = createSearchSourceBuilder(query, page, sorts);
 
     return execute(searchSourceBuilder);
   }

--- a/src/main/java/bio/overture/songsearch/utils/ElasticsearchQueryUtils.java
+++ b/src/main/java/bio/overture/songsearch/utils/ElasticsearchQueryUtils.java
@@ -54,8 +54,7 @@ public class ElasticsearchQueryUtils {
   }
 
   /**
-   * For each argument, find its query producer function and apply the argument value ANDing it in a
-   * bool query
+   * For each sorts, find its SortBuilder and add the sort order value then collect them all in a list
    *
    * @param sorts List of Sort objects
    * @return List of FiledSortBuilder

--- a/src/main/java/bio/overture/songsearch/utils/JacksonUtils.java
+++ b/src/main/java/bio/overture/songsearch/utils/JacksonUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package bio.overture.songsearch.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+
+public class JacksonUtils {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @SneakyThrows
+  public static <T> T convertValue(Object fromValue, Class<T> toValueType) {
+    return OBJECT_MAPPER.convertValue(fromValue, toValueType);
+  }
+}

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -149,8 +149,42 @@ type SampleMatchedAnalysisPair {
     tumourSampleAnalysis: Analysis
 }
 
+enum AnalysisSortField {
+    analysisId,
+    analysisType,
+    analysisVersion,
+    analysisState,
+    studyId,
+    donorId,
+    specimenId,
+    sampleId,
+    runId
+}
+
+enum SortOrder {
+    asc,
+    desc
+}
+
+input AnalysisSort {
+    fieldName: AnalysisSortField!
+    order: SortOrder!
+}
+
+type ProbeResultInfo {
+    contentCount: String
+    hasNextFrom: String!
+    totalHits: String!
+}
+
+type AnalysesProbeResult {
+    content: [Analysis!]
+    info: ProbeResultInfo!
+}
+
 extend type Query {
     analyses(filter: AnalysisFilter, page: Page): [Analysis]
     files(filter: FileFilter, page: Page): [File]
     sampleMatchedAnalysisPairs(analysisId: String!): [SampleMatchedAnalysisPair]
+    probeAnalyses(filter: AnalysisFilter, page: Page, sorts: [AnalysisSort!]): AnalysesProbeResult
 }


### PR DESCRIPTION
Related issue: https://github.com/icgc-argo/rdpc-gateway/issues/58

Changes:
- Added new query called `probeAnalyses` which returns a list of analysis content and page info totalHits, hasNextFrom, & contentCount
- Added sorts capability in analysis repositiory ( the new probeAnalyses makes use of this)
- Some light refactoring