### PR TITLE
all matched pair query checks studyId and donorId

### DIFF
--- a/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
+++ b/src/main/java/bio/overture/songsearch/graphql/AnalysisDataFetcher.java
@@ -18,8 +18,6 @@
 
 package bio.overture.songsearch.graphql;
 
-import static bio.overture.songsearch.config.constants.SearchFields.ANALYSIS_TYPE;
-import static bio.overture.songsearch.config.constants.SearchFields.DONOR_ID;
 import static bio.overture.songsearch.utils.JacksonUtils.convertValue;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
@@ -93,10 +91,8 @@ public class AnalysisDataFetcher {
 
   public DataFetcher<List<SampleMatchedAnalysisPair>> getSampleMatchedAnalysesForDonorFetcher() {
     return env -> {
-      val req = (Map<String, Object>) env.getArguments().get("req");
-      val donorId = req.get(DONOR_ID).toString();
-      val analysisType = req.get(ANALYSIS_TYPE) == null ? null : req.get(ANALYSIS_TYPE).toString();
-      return analysisService.getSampleMatchedAnalysesForDonor(donorId, analysisType);
+      val req = convertValue(env.getArguments().get("req"), SampleMatchedAnalysesForDonorReq.class);
+      return analysisService.getSampleMatchedAnalysesForDonor(req);
     };
   }
 }

--- a/src/main/java/bio/overture/songsearch/model/SampleMatchedAnalysesForDonorReq.java
+++ b/src/main/java/bio/overture/songsearch/model/SampleMatchedAnalysesForDonorReq.java
@@ -1,0 +1,13 @@
+package bio.overture.songsearch.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data
+@NoArgsConstructor
+public class SampleMatchedAnalysesForDonorReq {
+  @NonNull private String donorId;
+  private String studyId;
+  private String analysisType;
+}

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -222,6 +222,7 @@ type AggregationResult {
 
 input SampleMatchedAnalysesForDonorReq {
     donorId: String!
+    studyId: String
     analysisType: String
 }
 

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -232,7 +232,8 @@ extend type Query {
     files(filter: FileFilter, page: Page, sorts: [FileSort!]): FilesSearchResult!
     aggregateFiles(filter: FileFilter): AggregationResult!
     """
-    Given an analysisId, match it to its tumour-normal counter part with same experimental strategy.
+    Given an analysisId, match it to its tumour-normal counter part with same experimental strategy,
+    donorId and studyId.
     If analysis is tumour matches matchedNormalSubmitterSampleId to analyses with same submitterSampleId.
     If analysis is normal matches submitterSampleId and matchedNormalSubmitterSampleId.
     Non PUBLISHED analyses are ignored.
@@ -240,8 +241,10 @@ extend type Query {
     sampleMatchedAnalysisPairs(analysisId: String!): [SampleMatchedAnalysisPair]
     """
     Given a donorId, this query fetches all of its published normal analyses then fetches all
-    published matched tumour analyses with same analysis type and experimental strategy.
-    The analysisType can also be included to further filter the pairs by type.
+    published matched tumour analyses with same analysis type, studyId, donorId and
+    experimental strategy.
+    The analysisType can be included to further filter the pairs by type.
+    The studyId can be included to only fetch pairs for donor within a study.
     """
     sampleMatchedAnalysesForDonor(req: SampleMatchedAnalysesForDonorReq!): [SampleMatchedAnalysisPair]
 }


### PR DESCRIPTION
changes:
- sampleMatchedAnalysesForDonor now has optional studyId to further filter matched pairs in single study only
- fix sampleMatchedAnalysisPairs to match sampleIds, donorIds and studyIds

issue: https://github.com/icgc-argo/song-search/issues/67