### PR TITLE
Send kafka msg to ingest #164

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
         <!-- Graphql java dependencies -->
         <dependency>
             <groupId>com.graphql-java</groupId>

--- a/src/main/java/bio/overture/songsearch/config/kafka/AnalysisMessage.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/AnalysisMessage.java
@@ -17,12 +17,9 @@
 
 package bio.overture.songsearch.config.kafka;
 
-import bio.overture.songsearch.model.Analysis;
-import bio.overture.songsearch.model.enums.AnalysisState;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.*;
-
 import static lombok.AccessLevel.PRIVATE;
+import bio.overture.songsearch.model.enums.AnalysisState;
+import lombok.*;
 
 @Value
 // Note: although the AllArgs and NoArgs combination below seems odd,
@@ -45,16 +42,20 @@ public class AnalysisMessage {
         analysis.getStudyId(),
         analysis.getAnalysisState().toString(),
         analysis.getRepositories().get(0).getCode(),
-        new Analysis(analysis.getAnalysisId(), new AnalysisType(analysis.getAnalysisType()), analysis.getAnalysisState(), analysis.getStudyId() ));
+        new Analysis(
+            analysis.getAnalysisId(),
+            new AnalysisType(analysis.getAnalysisType()),
+            analysis.getAnalysisState(),
+            analysis.getStudyId()));
   }
 
   @Value
   @AllArgsConstructor
-  private static class Analysis{
-     String analysisId;
-     AnalysisType analysisType;
-     AnalysisState analysisState;
-     String studyId;
+  private static class Analysis {
+    String analysisId;
+    AnalysisType analysisType;
+    AnalysisState analysisState;
+    String studyId;
   }
 
   @Data

--- a/src/main/java/bio/overture/songsearch/config/kafka/AnalysisMessage.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/AnalysisMessage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018. Ontario Institute for Cancer Research
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package bio.overture.songsearch.config.kafka;
+
+import bio.overture.songsearch.model.Analysis;
+import bio.overture.songsearch.model.enums.AnalysisState;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Value
+// Note: although the AllArgs and NoArgs combination below seems odd,
+// it allows Jackson to deserialize to an immutable object without using any additional annotations.
+@AllArgsConstructor
+@NoArgsConstructor(force = true, access = PRIVATE)
+public class AnalysisMessage {
+
+  @NonNull private final String analysisId;
+  @NonNull private final String studyId;
+  @NonNull private final String state;
+  @NonNull private final String songServerId;
+  @NonNull private final Analysis analysis;
+
+  public static AnalysisMessage createAnalysisMessage(
+      bio.overture.songsearch.model.Analysis analysis, String songServerId) {
+
+    return new AnalysisMessage(
+        analysis.getAnalysisId(),
+        analysis.getStudyId(),
+        analysis.getAnalysisState().toString(),
+        analysis.getRepositories().get(0).getCode(),
+        new Analysis(analysis.getAnalysisId(), new AnalysisType(analysis.getAnalysisType()), analysis.getAnalysisState(), analysis.getStudyId() ));
+  }
+
+  @Value
+  @AllArgsConstructor
+  private static class Analysis{
+     String analysisId;
+     AnalysisType analysisType;
+     AnalysisState analysisState;
+     String studyId;
+  }
+
+  @Data
+  @AllArgsConstructor
+  public static class AnalysisType {
+    String name;
+  }
+}

--- a/src/main/java/bio/overture/songsearch/config/kafka/DefaultSender.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/DefaultSender.java
@@ -1,11 +1,13 @@
 package bio.overture.songsearch.config.kafka;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-public class DefaultSender implements Sender{
+@Component
+public class DefaultSender implements Sender {
 
   public void send(String payload, String key) {
-    log.debug("key: "+key);
+    log.debug("key: " + key);
   }
 }

--- a/src/main/java/bio/overture/songsearch/config/kafka/DefaultSender.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/DefaultSender.java
@@ -1,0 +1,11 @@
+package bio.overture.songsearch.config.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DefaultSender implements Sender{
+
+  public void send(String payload, String key) {
+    log.debug("key: "+key);
+  }
+}

--- a/src/main/java/bio/overture/songsearch/config/kafka/KafkaConfig.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/KafkaConfig.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 
 @Configuration
+@Profile("kafka")
 public class KafkaConfig {
 
   @Value("${spring.kafka.bootstrap-servers}")

--- a/src/main/java/bio/overture/songsearch/config/kafka/KafkaConfig.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/KafkaConfig.java
@@ -1,0 +1,53 @@
+package bio.overture.songsearch.config.kafka;
+
+
+import lombok.val;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Configuration
+public class KafkaConfig {
+
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Value("${spring.kafka.template.default-topic}")
+  private String defaultTopic;
+
+  @Bean
+  public Map<String, Object> producerConfigs() {
+    val props = new HashMap<String, Object>();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    return props;
+  }
+
+  @Bean
+  public ProducerFactory<String, String> producerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
+  }
+
+  @Bean
+  public KafkaTemplate<String, String> kafkaTemplate() {
+    val template = new KafkaTemplate<>(producerFactory());
+    template.setDefaultTopic(defaultTopic);
+    return template;
+  }
+
+  @Bean
+  public KafkaSender sender() {
+    return new KafkaSender();
+  }
+}

--- a/src/main/java/bio/overture/songsearch/config/kafka/KafkaConfig.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/KafkaConfig.java
@@ -1,6 +1,7 @@
 package bio.overture.songsearch.config.kafka;
 
-
+import java.util.HashMap;
+import java.util.Map;
 import lombok.val;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -11,10 +12,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-
-import java.util.HashMap;
-import java.util.Map;
-
 
 @Configuration
 @Profile("kafka")
@@ -45,6 +42,7 @@ public class KafkaConfig {
   public KafkaTemplate<String, String> kafkaTemplate() {
     val template = new KafkaTemplate<>(producerFactory());
     template.setDefaultTopic(defaultTopic);
+    System.out.println("defaultTopic: " + defaultTopic);
     return template;
   }
 

--- a/src/main/java/bio/overture/songsearch/config/kafka/KafkaSender.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/KafkaSender.java
@@ -1,0 +1,16 @@
+package bio.overture.songsearch.config.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Slf4j
+public class KafkaSender {
+  @Autowired
+  private KafkaTemplate<String, String> kafkaTemplate;
+
+  public void send(String payload, String key) {
+    log.debug("sending payload='{}' to topic='{}'", payload, kafkaTemplate.getDefaultTopic());
+    kafkaTemplate.send(kafkaTemplate.getDefaultTopic(), key, payload);
+  }
+}

--- a/src/main/java/bio/overture/songsearch/config/kafka/KafkaSender.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/KafkaSender.java
@@ -8,13 +8,10 @@ import org.springframework.kafka.core.KafkaTemplate;
 @Slf4j
 @Profile("kafka")
 public class KafkaSender implements Sender {
-  @Autowired
-  private KafkaTemplate<String, String> kafkaTemplate;
-
+  @Autowired private KafkaTemplate<String, String> kafkaTemplate;
 
   public void send(String payload, String key) {
     log.debug("sending payload='{}' to topic='{}'", payload, kafkaTemplate.getDefaultTopic());
     kafkaTemplate.send(kafkaTemplate.getDefaultTopic(), key, payload);
   }
-
 }

--- a/src/main/java/bio/overture/songsearch/config/kafka/KafkaSender.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/KafkaSender.java
@@ -2,15 +2,19 @@ package bio.overture.songsearch.config.kafka;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @Slf4j
-public class KafkaSender {
+@Profile("kafka")
+public class KafkaSender implements Sender {
   @Autowired
   private KafkaTemplate<String, String> kafkaTemplate;
+
 
   public void send(String payload, String key) {
     log.debug("sending payload='{}' to topic='{}'", payload, kafkaTemplate.getDefaultTopic());
     kafkaTemplate.send(kafkaTemplate.getDefaultTopic(), key, payload);
   }
+
 }

--- a/src/main/java/bio/overture/songsearch/config/kafka/Sender.java
+++ b/src/main/java/bio/overture/songsearch/config/kafka/Sender.java
@@ -1,0 +1,5 @@
+package bio.overture.songsearch.config.kafka;
+
+public interface Sender {
+  void send(String payload, String key);
+}

--- a/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
+++ b/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
@@ -52,6 +52,8 @@ public class GraphQLProvider {
   private final AnalysisDataFetcher analysisDataFetcher;
   private final FileDataFetcher fileDataFetcher;
   private final EntityDataFetcher entityDataFetcher;
+
+  private final StartAutomationMutation startAutomationMutation;
   private final AuthProperties authProperties;
   private GraphQL graphQL;
   private GraphQLSchema graphQLSchema;
@@ -61,10 +63,12 @@ public class GraphQLProvider {
       AnalysisDataFetcher analysisDataFetcher,
       FileDataFetcher fileDataFetcher,
       EntityDataFetcher entityDataFetcher,
+      StartAutomationMutation startAutomationMutation,
       AuthProperties authProperties) {
     this.analysisDataFetcher = analysisDataFetcher;
     this.fileDataFetcher = fileDataFetcher;
     this.entityDataFetcher = entityDataFetcher;
+    this.startAutomationMutation=startAutomationMutation;
     this.authProperties = authProperties;
   }
 
@@ -147,6 +151,11 @@ public class GraphQLProvider {
                 .dataFetcher(
                     "sampleMatchedAnalysesForDonor",
                     analysisDataFetcher.getSampleMatchedAnalysesForDonorFetcher()))
+        .type(
+            newTypeWiring("Mutation")
+                .dataFetcher("startAutomation", startAutomationMutation.startAutomationResolver())
+        )
+
         .build();
   }
 

--- a/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
+++ b/src/main/java/bio/overture/songsearch/graphql/GraphQLProvider.java
@@ -68,7 +68,7 @@ public class GraphQLProvider {
     this.analysisDataFetcher = analysisDataFetcher;
     this.fileDataFetcher = fileDataFetcher;
     this.entityDataFetcher = entityDataFetcher;
-    this.startAutomationMutation=startAutomationMutation;
+    this.startAutomationMutation = startAutomationMutation;
     this.authProperties = authProperties;
   }
 
@@ -153,9 +153,7 @@ public class GraphQLProvider {
                     analysisDataFetcher.getSampleMatchedAnalysesForDonorFetcher()))
         .type(
             newTypeWiring("Mutation")
-                .dataFetcher("startAutomation", startAutomationMutation.startAutomationResolver())
-        )
-
+                .dataFetcher("startAutomation", startAutomationMutation.startAutomationResolver()))
         .build();
   }
 

--- a/src/main/java/bio/overture/songsearch/graphql/StartAutomationMutation.java
+++ b/src/main/java/bio/overture/songsearch/graphql/StartAutomationMutation.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package bio.overture.songsearch.graphql;
+
+import bio.overture.songsearch.model.Analysis;
+import bio.overture.songsearch.model.SearchResult;
+import bio.overture.songsearch.model.Sort;
+import bio.overture.songsearch.service.AnalysisService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import graphql.schema.DataFetcher;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+import static bio.overture.songsearch.utils.JacksonUtils.convertValue;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+
+@Component
+@Slf4j
+public class StartAutomationMutation {
+
+  private final AnalysisService analysisService;
+
+  @Autowired
+  public StartAutomationMutation(AnalysisService analysisService) {
+    this.analysisService = analysisService;
+  }
+
+
+  public DataFetcher<Analysis> startAutomationResolver() {
+    return env -> {
+      val args = env.getArguments();
+
+      val filter = ImmutableMap.<String, Object>builder();
+      val page = ImmutableMap.<String, Integer>builder();
+      val sorts = ImmutableList.<Sort>builder();
+
+      if (args != null) {
+        if (args.get("filter") != null) filter.putAll((Map<String, Object>) args.get("filter"));
+        if (args.get("page") != null) page.putAll((Map<String, Integer>) args.get("page"));
+        if (args.get("sorts") != null) {
+          val rawSorts = (List<Object>) args.get("sorts");
+          sorts.addAll(
+              rawSorts.stream()
+                  .map(sort -> convertValue(sort, Sort.class))
+                  .collect(toUnmodifiableList()));
+        }
+      }
+
+      Analysis analysis = analysisService.getAnalysisById(env.getArguments().get("analysisId").toString());
+      log.debug("Analysis fetched: " + analysis);
+
+      analysisService.sendAnalysisMessage(analysis);
+      log.debug("Message sent to kafka queue");
+      return analysis;
+    };
+  }
+  
+
+}

--- a/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
+++ b/src/main/java/bio/overture/songsearch/repository/AnalysisRepository.java
@@ -84,7 +84,9 @@ public class AnalysisRepository {
             REPOSITORY_CODE,
             value ->
                 new NestedQueryBuilder(
-                    "repositories", new TermQueryBuilder("repositories.code", value), ScoreMode.None))
+                    "repositories",
+                    new TermQueryBuilder("repositories.code", value),
+                    ScoreMode.None))
         .put(
             DONOR_ID,
             value ->

--- a/src/main/java/bio/overture/songsearch/service/AnalysisService.java
+++ b/src/main/java/bio/overture/songsearch/service/AnalysisService.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.search.SearchHit;
@@ -45,6 +46,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class AnalysisService {
 
   private final AnalysisRepository analysisRepository;
@@ -228,8 +230,7 @@ public class AnalysisService {
   @SneakyThrows
   public void sendAnalysisMessage(Analysis analysis) {
     val message = createAnalysisMessage(analysis, songServerId);
-    System.out.println("Message payload: "+message);
-    System.out.println("message after mapping: "+new ObjectMapper().writeValueAsString(message));
+    log.debug("Message payload:: "+new ObjectMapper().writeValueAsString(message));
     sender.send(new ObjectMapper().writeValueAsString(message), message.getAnalysisId());
   }
 

--- a/src/main/java/bio/overture/songsearch/service/AnalysisService.java
+++ b/src/main/java/bio/overture/songsearch/service/AnalysisService.java
@@ -21,17 +21,14 @@ package bio.overture.songsearch.service;
 import static bio.overture.songsearch.config.constants.EsDefaults.ES_PAGE_DEFAULT_FROM;
 import static bio.overture.songsearch.config.constants.EsDefaults.ES_PAGE_DEFAULT_SIZE;
 import static bio.overture.songsearch.config.constants.SearchFields.*;
-import static bio.overture.songsearch.config.kafka.AnalysisMessage.createAnalysisMessage;
 import static bio.overture.songsearch.model.enums.AnalysisState.PUBLISHED;
 import static bio.overture.songsearch.model.enums.SpecimenType.NORMAL;
 import static bio.overture.songsearch.model.enums.SpecimenType.TUMOUR;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static java.util.stream.Stream.empty;
 
-import bio.overture.songsearch.config.kafka.KafkaSender;
 import bio.overture.songsearch.model.*;
 import bio.overture.songsearch.repository.AnalysisRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.util.*;
 import java.util.stream.Stream;
@@ -50,18 +47,12 @@ import org.springframework.stereotype.Service;
 public class AnalysisService {
 
   private final AnalysisRepository analysisRepository;
-  private String songServerId;
-  private final KafkaSender sender;
-
 
   @Autowired
-  public AnalysisService(AnalysisRepository analysisRepository,
-                         @NonNull KafkaSender sender) {
+  public AnalysisService(AnalysisRepository analysisRepository) {
 
     this.analysisRepository = analysisRepository;
-    this.sender = sender;
   }
-
 
   private static Analysis hitToAnalysis(SearchHit hit) {
     val sourceMap = hit.getSourceAsMap();
@@ -226,12 +217,4 @@ public class AnalysisService {
       this.sampleType = sample.getSampleType();
     }
   }
-
-  @SneakyThrows
-  public void sendAnalysisMessage(Analysis analysis) {
-    val message = createAnalysisMessage(analysis, songServerId);
-    log.debug("Message payload:: "+new ObjectMapper().writeValueAsString(message));
-    sender.send(new ObjectMapper().writeValueAsString(message), message.getAnalysisId());
-  }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,3 +34,15 @@ auth:
         - RDPC-DEV.READ
       queryAndMutation:
         - RDPC-DEV.WRITE
+---
+
+spring:
+  config:
+    activate:
+      on-profile: kafka
+  kafka:
+    bootstrap-servers: localhost:9092
+    template:
+      default-topic: automation_trigger #song-analysis
+
+songServerId: submission-song.collab

--- a/src/main/resources/schema.graphql
+++ b/src/main/resources/schema.graphql
@@ -251,3 +251,11 @@ extend type Query {
     """
     sampleMatchedAnalysesForDonor(req: SampleMatchedAnalysesForDonorReq!): [SampleMatchedAnalysisPair]
 }
+
+type Mutation {
+    startAutomation(analysisId: String!): MutationResponse
+}
+
+type MutationResponse {
+    analysisId: ID
+}


### PR DESCRIPTION
Changes include: addition of a mutation gql api, kafka configurations and modifications in gql schema. 
Song Search will respond to user action on the WES UI, fetch the analysis details and send a kafka event to the ingest node to trigger the automation cycle.